### PR TITLE
Update fortnightly, takes too much quota to do weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Top PyPI Packages
 
-A weekly dump of the 5,000 most-downloaded packages from PyPI:
+A fortnighly dump of the 5,000 most-downloaded packages from PyPI:
 
 * https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json
 * https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-s
 
 ```bash
 crontab -e
-17 15 * * Tue /home/botuser/github/top-pypi-packages/top-pypi-packages.sh > /tmp/top-pypi-packages.log 2>&1
+# Only for odd weeks https://stackoverflow.com/a/19278657/724176
+30 17 * * Fri expr \( `date +\%s` / 604800 + 1 \) \% 2 > /dev/null || ( eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa-top-pypi-packages; /home/botuser/github/top-pypi-packages/top-pypi-packages.sh ) > /tmp/top-pypi-packages.log 2>&1
 ```

--- a/index.html
+++ b/index.html
@@ -60,14 +60,14 @@
       outline: 0.05em solid #090;
     }
   </style>
-  <title>Top PyPI Packages: A weekly dump of the 5,000 most-downloaded packages from PyPI</title>
+  <title>Top PyPI Packages: A fortnighly dump of the 5,000 most-downloaded packages from PyPI</title>
   <meta property="og:title" content="Top PyPI Packages">
   <meta property="og:type" content="website">
   <!--<meta property="og:image" content="https://hugovk.github.io/top-pypi-packages/image.png">-->
   <!--<meta property="og:image:width" content="630">-->
   <!--<meta property="og:image:height" content="630">-->
   <meta property="og:url" content="https://hugovk.github.io/top-pypi-packages/">
-  <meta property="og:description" content="A weekly dump of the 5,000 most-downloaded packages from PyPI">
+  <meta property="og:description" content="A fortnighly dump of the 5,000 most-downloaded packages from PyPI">
 </head>
 <body ng-app="app" ng-controller="packageCtrl">
   <div class="container">
@@ -75,7 +75,7 @@
       <div class="col-sm-6">
       <h1 id="top">Top PyPI Packages</h1>
         <h2 id="what">What is this?</h2>
-        <p>A weekly dump of the 5,000 most-downloaded packages from PyPI.</p>
+        <p>A fortnighly dump of the 5,000 most-downloaded packages from PyPI.</p>
         <ul>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json</a></li>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json</a></li>
@@ -121,7 +121,7 @@
       </div>
     </div>
     <footer>
-      <p>Last updated <span ng-bind="last_update"></span>. (Updated weekly.)</p>
+      <p>Last updated <span ng-bind="last_update"></span>. (Updated fortnighly.)</p>
       <a class="github-fork-ribbon" href="https://github.com/hugovk/top-pypi-packages" target="_blank" rel="noopener" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
     </footer>
   </div>


### PR DESCRIPTION
It takes up too much BigQuery quota to fetch both 30-days and 365-days data every week. 

It can usually fetch one. One solution would be to update 30-days one week, and 365-days the other week, but it's easier and a bit cleaner to do them both at the same time, every other week. It's most important that the data is updated regularly than never.

The crontab entry now looks like:

```
# Only for odd weeks https://stackoverflow.com/a/19278657/724176
30 17 * * Fri expr \( `date +\%s` / 604800 + 1 \) \% 2 > /dev/null || ( eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa-top-pypi-packages; /home/botuser/github/top-pypi-packages/top-pypi-packages.sh ) > /tmp/top-pypi-packages.log 2>&1
```

TODO

* [ ] When merged, update description at the top of https://github.com/hugovk/top-pypi-packages