### PR TITLE
Update monthly, takes too much quota to do fortnightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Top PyPI Packages
 
-A fortnightly dump of the 4,000 most-downloaded packages from PyPI:
+A monthly dump of the 4,000 most-downloaded packages from PyPI:
 
 * https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json
 * https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-s
 
 ```bash
 crontab -e
-# Only for odd weeks https://stackoverflow.com/a/19278657/724176
-30 17 * * Fri expr \( `date +\%s` / 604800 + 1 \) \% 2 > /dev/null || ( eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa-top-pypi-packages; /home/botuser/github/top-pypi-packages/top-pypi-packages.sh ) > /tmp/top-pypi-packages.log 2>&1
+# First of the month
+30 17 1 * * ( eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa-top-pypi-packages; /home/botuser/github/top-pypi-packages/top-pypi-packages.sh ) > /tmp/top-pypi-packages.log 2>&1
 ```

--- a/index.html
+++ b/index.html
@@ -60,14 +60,14 @@
       outline: 0.05em solid #090;
     }
   </style>
-  <title>Top PyPI Packages: A fortnightly dump of the 4,000 most-downloaded packages from PyPI</title>
+  <title>Top PyPI Packages: A monthly dump of the 4,000 most-downloaded packages from PyPI</title>
   <meta property="og:title" content="Top PyPI Packages">
   <meta property="og:type" content="website">
   <!--<meta property="og:image" content="https://hugovk.github.io/top-pypi-packages/image.png">-->
   <!--<meta property="og:image:width" content="630">-->
   <!--<meta property="og:image:height" content="630">-->
   <meta property="og:url" content="https://hugovk.github.io/top-pypi-packages/">
-  <meta property="og:description" content="A fortnightly dump of the 4,000 most-downloaded packages from PyPI">
+  <meta property="og:description" content="A monthly dump of the 4,000 most-downloaded packages from PyPI">
 </head>
 <body ng-app="app" ng-controller="packageCtrl">
   <div class="container">
@@ -75,7 +75,7 @@
       <div class="col-sm-6">
       <h1 id="top">Top PyPI Packages</h1>
         <h2 id="what">What is this?</h2>
-        <p>A fortnightly dump of the 4,000 most-downloaded packages from PyPI.</p>
+        <p>A monthly dump of the 4,000 most-downloaded packages from PyPI.</p>
         <ul>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json</a></li>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json</a></li>
@@ -130,7 +130,7 @@
       </div>
     </div>
     <footer>
-      <p>Last updated <span ng-bind="last_update"></span>. (Updated fortnightly.)</p>
+      <p>Last updated <span ng-bind="last_update"></span>. (Updated monthly.)</p>
       <a class="github-fork-ribbon" href="https://github.com/hugovk/top-pypi-packages" target="_blank" rel="noopener" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
     </footer>
   </div>


### PR DESCRIPTION
Follow on from https://github.com/hugovk/top-pypi-packages/pull/5...

It now takes too much to do fortnightly. From the logs:


```
Fri Jan 31 17:30:01 EET 2020
From github.com:hugovk/top-pypi-packages
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Traceback (most recent call last):
  File "/usr/local/bin/pypinfo", line 11, in <module>
    sys.exit(pypinfo())
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/pypinfo/cli.py", line 150, in pypinfo
    query_rows = query_job.result(timeout=timeout // 1000)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/job.py", line 1932, in result
    super(QueryJob, self).result(timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/job.py", line 528, in result
    return super(_AsyncJob, self).result(timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/future/polling.py", line 106, in result
    self._blocking_poll(timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/job.py", line 1906, in _blocking_poll
    super(QueryJob, self)._blocking_poll(timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/future/polling.py", line 85, in _blocking_poll
    retry_(self._done_or_raise)()
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/future/polling.py", line 62, in _done_or_raise
    if not self.done():
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/job.py", line 1894, in done
    project=self.project, timeout_ms=timeout_ms)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/client.py", line 523, in _get_query_results
    retry, method='GET', path=path, query_params=extra_params)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/bigquery/client.py", line 275, in _call_api
    return call()
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/_http.py", line 293, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.Forbidden: 403 GET https://www.googleapis.com/bigquery/v2/projects/top-pypi-packages/queries/9098e94d-b383-46fc-862a-558234ec8e7c?maxResults=0&timeoutMs=10000: Quota exceeded: Your project exceeded quota for free query bytes scanned. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors
```

New crontab:

```crontab
# First of the month
30 17 1 * * ( eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa-top-pypi-packages; /home/botuser/github/top-pypi-packages/top-pypi-packages$
```

`https://crontab.guru/#30_17_1_*_*`

If it starts taking too much quota for monthly, maybe it'll be time to drop the top-365 data, or update that less frequently (annually?).