### PR TITLE
Fix links pointing to the wrong resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,8 @@
         </ul>
         <p>Minified:</p>
         <ul>
-          <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json</a></li>
-          <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json</a></li>
+          <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json</a></li>
+          <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json</a></li>
         </ul>
         <h2 id="thanks">Thanks</h2>
         <p>Thanks to <a href="https://pypi.org/">PyPI</a>, <a href="https://cloud.google.com/bigquery/">Google BigQuery</a>, <a href="https://github.com/ofek/pypinfo">pypinfo</a> and <a href="https://pythonwheels.com/">Python Wheels</a>.</p>


### PR DESCRIPTION
I linked on these links and was surprised to see that I didn't get the minified JSON dump I wanted 🙁

Also, many thanks for the all work you do in the Python community, especially in the Black repository @hugovk! 🎉 