### PR TITLE
Increase data from 5k to 8k packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/116806538.svg)](https://zenodo.org/badge/latestdoi/116806538)
 
-A monthly dump of the 5,000 most-downloaded packages from PyPI:
+A monthly dump of the 8,000 most-downloaded packages from PyPI:
 
 * https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
 

--- a/generate.sh
+++ b/generate.sh
@@ -16,9 +16,5 @@ python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
 # Generate and minify for 30 days
-/home/botuser/.local/bin/pypinfo --json --indent 0 --limit 5000 --days  30 "" project > top-pypi-packages-30-days.json
+/home/botuser/.local/bin/pypinfo --json --indent 0 --limit 8000 --days  30 "" project > top-pypi-packages-30-days.json
 jq -c . < top-pypi-packages-30-days.json > top-pypi-packages-30-days.min.json
-
-# Generate and minify for 365 days
-#/home/botuser/.local/bin/pypinfo --json --indent 0 --limit 5000 --days 365 "" project > top-pypi-packages-365-days.json
-#jq -c . < top-pypi-packages-365-days.json > top-pypi-packages-365-days.min.json

--- a/index.html
+++ b/index.html
@@ -79,14 +79,14 @@
       outline: inherit;
     }
   </style>
-  <title>Top PyPI Packages: A monthly dump of the 5,000 most-downloaded packages from PyPI</title>
+  <title>Top PyPI Packages: A monthly dump of the 8,000 most-downloaded packages from PyPI</title>
   <meta property="og:title" content="Top PyPI Packages">
   <meta property="og:type" content="website">
   <!--<meta property="og:image" content="https://hugovk.github.io/top-pypi-packages/image.png">-->
   <!--<meta property="og:image:width" content="630">-->
   <!--<meta property="og:image:height" content="630">-->
   <meta property="og:url" content="https://hugovk.github.io/top-pypi-packages/">
-  <meta property="og:description" content="A monthly dump of the 5,000 most-downloaded packages from PyPI">
+  <meta property="og:description" content="A monthly dump of the 8,000 most-downloaded packages from PyPI">
 </head>
 <body ng-app="app" ng-controller="packageCtrl">
   <div class="container">
@@ -95,7 +95,7 @@
       <h1 id="top">Top PyPI Packages</h1>
       <a href="https://zenodo.org/badge/latestdoi/116806538"><img alt="DOI" src="https://zenodo.org/badge/116806538.svg"></a>
         <h2 id="what">What is this?</h2>
-        <p>A monthly dump of the 5,000 most-downloaded packages from PyPI.</p>
+        <p>A monthly dump of the 8,000 most-downloaded packages from PyPI.</p>
         <ul>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json</a></li>
         </ul>
@@ -129,7 +129,7 @@
         </div>
         <button ng-click="show(100)" >Show 100</button>
         <button ng-click="show(1000)" >Show 1,000</button>
-        <button ng-click="show(5000)" >Show 5,000</button>
+        <button ng-click="show(8000)" >Show 8,000</button>
          <div class="list">
           <span ng-hide="packages">JavaScript must be enabled to display the list of packages.</span>
           <a ng-repeat="package in packages" ng-href="https://pypi.org/project/{{ package.project }}" class="" ng-attr-title="{{ package.project }}">
@@ -146,7 +146,7 @@
         </div>
         <button ng-click="show(100)" >Show 100</button>
         <button ng-click="show(1000)" >Show 1,000</button>
-        <button ng-click="show(5000)" >Show 5,000</button>
+        <button ng-click="show(8000)" >Show 8,000</button>
       </div>
     </div>
     <footer>


### PR DESCRIPTION
We get 1 TB of free BigQuery quota per month.

This chart shows fairly linear increasing usage over time, taken from `bytes_billed` in each release's JSON:

![Screenshot_20230831_231545_Sheets](https://github.com/hugovk/top-pypi-packages/assets/1324225/fec236fd-42a0-4213-bb14-515a0ee2e143)

The gap indicated where we switched from 4k to 5k projects.

We can probably bump up to 8k, but we'll need to keep an eye on the bytes billed as it increases over time. 