### PR TITLE
Fetch data for all installers, not only pip

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.py]
+indent_size = 4

--- a/generate.sh
+++ b/generate.sh
@@ -16,7 +16,7 @@ python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
 # Generate and minify for 30 days
-/home/botuser/.local/bin/pypinfo --json --indent 0 --limit 8000 --days  30 "" project > top-pypi-packages-30-days.json
+/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 8000 --days 30 "" project > top-pypi-packages-30-days.json
 jq -c . < top-pypi-packages-30-days.json > top-pypi-packages-30-days.min.json
 echo 'download_count,project' > top-pypi-packages-30-days.csv
 jq -r '.rows[] | [.download_count, .project] | @csv' top-pypi-packages-30-days.json >> top-pypi-packages-30-days.csv

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
         <p>A monthly dump of the 8,000 most-downloaded packages from PyPI.</p>
         <ul>
           <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json</a></li>
+          <li><a href="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.csv">https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.csv</a></li>
         </ul>
         <p>Unminified:</p>
         <ul>
@@ -114,6 +115,19 @@
           <li><a href="https://maxnoe.github.io/who-dropped-python2/">Who has already dropped Python 2 support?</a></li>
           <li><a href="https://py.wtf">py.wtf</a><!-- https://github.com/zsol/py.wtf/pull/89 --></li>
           <li>Something else? <a href="https://github.com/hugovk/top-pypi-packages/issues/new">Let us know!</a></li>
+        </ul>
+        <h2 id="changelog">Changelog</h2>
+        <ul>
+          <li>2018-01: Fetch data weekly for 500 packages over 365 days (<a href="https://github.com/hugovk/top-pypi-packages/commit/fa9774cd26f93aedbb6f27e0364687c2fd799f26">fa9774c</a>)</li>
+          <li>2018-01: Fetch data for 1,000 packages over 365 days (<a href="https://github.com/hugovk/top-pypi-packages/commit/7148b389bbde83ef1c8a06deebf47fb4f942dc40">7148b38</a>)</li>
+          <li>2018-01: Fetch data for 5,000 packages over 365 days (<a href="https://github.com/hugovk/top-pypi-packages/commit/47523f4334d05e53ecfde20cb29add5afaae5f8a">47523f4</a>)</li>
+          <li>2018-02: Fetch data for 5,000 packages over 30 and 365 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/2">#2</a>)</li>
+          <li>2019-10: Fetch data fortnightly (<a href="https://github.com/hugovk/top-pypi-packages/pull/5">#5</a>)</li>
+          <li>2019-12: Fetch data for 4,000 packages over 30 and 365 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/7">#7</a>)</li>
+          <li>2020-03: Fetch data monthly (<a href="https://github.com/hugovk/top-pypi-packages/pull/9">#9</a>)</li>
+          <li>2021-07: Fetch data for 5,000 packages over only 30 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/20">#20</a>)</li>
+          <li>2024-05: Provide data in CSV in addition to JSON (<a href="https://github.com/hugovk/top-pypi-packages/issues/31">#31</a>)</li>
+          <li>2024-11: Fetch data for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/issues/39">#39</a>)</li>
         </ul>
       </div>
       <div class="col-sm-6">


### PR DESCRIPTION
Helps https://github.com/hugovk/top-pypi-packages/issues/36.

```console
❯ pypinfo --help
...
Options:
...
  --all                   Show downloads by all installers, not only pip.
```

`pypinfo --all` tells it to fetch data for all installers, and not to filter to only pip (the default).

(`--all` was added to pypinfo in https://github.com/ofek/pypinfo/pull/51.)

This results in a cheaper BigQuery call: the pip-only query costs an extra 25% in bytes processed, in bytes billed, and in dollars; see https://github.com/hugovk/top-pypi-packages/issues/36#issuecomment-2409106375.

| installer_name | download_count |
| -------------- | -------------: |
| pip            |  1,121,198,711 |
| uv             |    117,194,833 |
| requests       |     29,828,272 |
| poetry         |     23,009,454 |
| None           |      8,916,745 |
| bandersnatch   |      6,171,555 |
| setuptools     |      1,362,797 |
| Bazel          |      1,280,271 |
| Browser        |      1,096,328 |
| Nexus          |        593,230 |
| Homebrew       |        510,247 |
| Artifactory    |         69,063 |
| pdm            |         62,904 |
| OS             |         13,108 |
| devpi          |          9,530 |
| conda          |          2,272 |
| pex            |            194 |
| Total          |  1,311,319,514 |

pip is still by far the most popular installer, and unsurprising uv is up there too, with about 10% of pip's downloads.

The others are 10% of uv or less. A lot of them are mirroring services, that we wanted to exclude before.

I think given uv's importance, and my expectation that it will continue to take a bigger share of the pie, plus especially the extra cost for filtering by just pip, means that we should switch to fetching data for all downloaders. Plus the others don't account for that much of the pie.

