### PR TITLE
Fetch data for 15k PyPI packages

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -15,20 +15,8 @@ python3 -m pip install -U pypinfo
 python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
-# Check if zip is installed
-if ! command -v zip &> /dev/null
-then
-    echo "zip not found, consider: apt install zip"
-    exit 1
-fi
-
 # Generate and minify
-/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 10000000 --days 29 "" project > top-pypi-packages-30-days-all.json
-python3 trim.py > top-pypi-packages-30-days.json
+/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days 29 "" project > top-pypi-packages-30-days.json
 jq -c . < top-pypi-packages-30-days.json > top-pypi-packages-30-days.min.json
-echo 'download_count,project' > top-pypi-packages-30-days-all.csv
 echo 'download_count,project' > top-pypi-packages-30-days.csv
-jq -r '.rows[] | [.download_count, .project] | @csv' top-pypi-packages-30-days-all.json >> top-pypi-packages-30-days-all.csv
-jq -r '.rows[] | [.download_count, .project] | @csv' top-pypi-packages-30-days.json     >> top-pypi-packages-30-days.csv
-zip top-pypi-packages-30-days-all.csv.zip  top-pypi-packages-30-days-all.csv
-zip top-pypi-packages-30-days-all.json.zip top-pypi-packages-30-days-all.json
+jq -r '.rows[] | [.download_count, .project] | @csv' top-pypi-packages-30-days.json >> top-pypi-packages-30-days.csv

--- a/index.html
+++ b/index.html
@@ -129,7 +129,10 @@
           <li>2021-07: Fetch data for 5,000 packages over only 30 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/20">#20</a>)</li>
           <li>2021-09: Fetch data for 8,000 packages (<a href="https://github.com/hugovk/top-pypi-packages/pull/30">#30</a>)</li>
           <li>2024-05: Provide data in CSV in addition to JSON (<a href="https://github.com/hugovk/top-pypi-packages/issues/31">#31</a>)</li>
-          <li>2024-11: Fetch data for all PyPI packages (<a href="https://github.com/hugovk/top-pypi-packages/issues/41">#41</a>)
+          <li><strike>2024-11: Fetch data for all PyPI packages (<a href="https://github.com/hugovk/top-pypi-packages/issues/41">#41</a>)
+            over 29 days (<a href="https://github.com/hugovk/top-pypi-packages/issues/42">#42</a>)
+            and for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/issues/39">#39</a>)</strike></li>
+          <li>2025-01: Fetch data for 15,000 PyPI packages (<a href="https://github.com/hugovk/top-pypi-packages/pulls/44">#44</a>)
             over 29 days (<a href="https://github.com/hugovk/top-pypi-packages/issues/42">#42</a>)
             and for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/issues/39">#39</a>)</li>
         </ul>


### PR DESCRIPTION
The attempt to fetch the data for _all_ PyPI packages (https://github.com/hugovk/top-pypi-packages/pull/41) was unsuccessful. From the logs:

```
generate.sh: line 26: 575013 Killed                  /home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 10000000 --days 29 "" project > top-pypi-packages-30-days-all.json
```

This had worked locally when testing with free quota. Perhaps it was a memory problem on the server. Anyway, let's go down from ~600k projects to a hopefully more manageable 15k. We can try and increase in later months. 

And there's a long tail in PyPI downloads (graphs from 10 Nov 2024), so the top end will be more useful:

![image](https://github.com/user-attachments/assets/cb37fcb3-8db9-433c-8d4e-c7b85f493512)

Same thing with log scale:

![image](https://github.com/user-attachments/assets/aac10958-6a61-44c5-9c80-f9d820d02c17)
