### PR TITLE
Fetch data for 28 days to stay within quota

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -16,8 +16,9 @@ python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
 # Generate and minify
-/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days 29 --test "" project
-/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days 29        "" project > top-pypi-packages-30-days.json
+days=28
+/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days --test "" project
+/home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days        "" project > top-pypi-packages-30-days.json
 jq -c . < top-pypi-packages-30-days.json > top-pypi-packages-30-days.min.json
 echo 'download_count,project' > top-pypi-packages-30-days.csv
 jq -r '.rows[] | [.download_count, .project] | @csv' top-pypi-packages-30-days.json >> top-pypi-packages-30-days.csv

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
           <li>2025-01: Fetch data for 15,000 PyPI packages (<a href="https://github.com/hugovk/top-pypi-packages/pulls/44">#44</a>)
             over 29 days (<a href="https://github.com/hugovk/top-pypi-packages/issues/42">#42</a>)
             and for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/issues/39">#39</a>)</li>
+          <li>2025-02: Fetch data for 28 days (<a href="https://github.com/hugovk/top-pypi-packages/issues/42">#45</a>)</li>
         </ul>
       </div>
       <div class="col-sm-6">


### PR DESCRIPTION
29 days uses too much quota:
```python
from google.cloud import bigquery

# Construct a BigQuery client object.
# client = bigquery.Client()
client = bigquery.Client.from_service_account_json("pypinfo-key.json")

job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)

# Start the query, passing in the extra configuration.
query_job = client.query(
    (
        """
        SELECT
          file.project as project,
          COUNT(*) as download_count,
        FROM `bigquery-public-data.pypi.file_downloads`
        WHERE timestamp BETWEEN TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -30 DAY) AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)
        GROUP BY
          project
        ORDER BY
          download_count DESC
        LIMIT 15000
        """
    ),
    job_config=job_config,
)  # Make an API request.



# A dry run query completes immediately.
print(
    f"This query will process {query_job.total_bytes_processed:,} bytes or"
    f" {query_job.total_bytes_processed / 2**40:.2f} TiB."
)
```
```console
❯ p dry-run.py
This query will process 1,125,717,300,161 bytes or 1.02 TiB.
```

Reducing by a day, `-30`->`-29` for a 28 day period should be okay:

```console
❯ p dry-run.py
This query will process 1,084,266,719,315 bytes or 0.99 TiB.
```

