### PR TITLE
Fetch data for 24 days to stay within quota

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -16,7 +16,7 @@ python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
 # Generate and minify
-days=27
+days=24
 /home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days --test "" project
 /home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days        "" project > top-pypi-packages.json
 jq -c . < top-pypi-packages.json > top-pypi-packages.min.json

--- a/index.html
+++ b/index.html
@@ -136,7 +136,8 @@
           <li>2025-01: Fetch data for 15,000 PyPI packages (<a href="https://github.com/hugovk/top-pypi-packages/pull/44">#44</a>)
             over 29 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/42">#42</a>)
             and for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/pull/39">#39</a>)</li>
-          <li>2025-02: Fetch data for 28 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/42">#45</a>)</li>
+          <li>2025-02: Fetch data for 28 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/45">#45</a>)</li>
+          <li>2025-04: Fetch data for 24 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/49">#49</a>)</li>
         </ul>
       </div>
       <div class="col-sm-6">


### PR DESCRIPTION
Dry runs:

```console
❯ pypinfo --all --indent 0 --limit 15000 --days 27 --dry-run "" project
Served from cache: False
Data processed: 1.10 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --all --indent 0 --limit 15000 --days 26 --dry-run "" project
Served from cache: False
Data processed: 1.06 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --all --indent 0 --limit 15000 --days 25 --dry-run "" project
Served from cache: False
Data processed: 1.01 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --all --indent 0 --limit 15000 --days 24 --dry-run "" project
Served from cache: False
Data processed: 984.76 GiB
Data billed: 0.00 B
Estimated cost: $0.00
```