### PR TITLE
Fetch data for 22 days to stay within quota

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -16,7 +16,7 @@ python3 -m pip --version
 /home/botuser/.local/bin/pypinfo --version
 
 # Generate and minify
-days=24
+days=22
 /home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days --test "" project
 /home/botuser/.local/bin/pypinfo --all --json --indent 0 --limit 15000 --days $days        "" project > top-pypi-packages.json
 jq -c . < top-pypi-packages.json > top-pypi-packages.min.json

--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
             and for all installers, not only pip (<a href="https://github.com/hugovk/top-pypi-packages/pull/39">#39</a>)</li>
           <li>2025-02: Fetch data for 28 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/45">#45</a>)</li>
           <li>2025-04: Fetch data for 24 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/49">#49</a>)</li>
+          <li>2025-05: Fetch data for 22 days (<a href="https://github.com/hugovk/top-pypi-packages/pull/50">#50</a>)</li>
         </ul>
       </div>
       <div class="col-sm-6">


### PR DESCRIPTION
```console
❯ pypinfo --dry-run --all --indent 0 --limit 15000 --days 25 "" project
Served from cache: False
Data processed: 1.14 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --dry-run --all --indent 0 --limit 15000 --days 24 "" project
Served from cache: False
Data processed: 1.09 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --dry-run --all --indent 0 --limit 15000 --days 23 "" project
Served from cache: False
Data processed: 1.03 TiB
Data billed: 0.00 B
Estimated cost: $0.00

❯ pypinfo --dry-run --all --indent 0 --limit 15000 --days 22 "" project
Served from cache: False
Data processed: 1005.35 GiB
Data billed: 0.00 B
Estimated cost: $0.00
```
